### PR TITLE
fix: mysql 8 Authentication problem

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   db:
-    image: mysql
+    image: mysql:5.7
     env_file: .env
     volumes:
        - ./storage/db-data/mysql:/var/lib/mysql


### PR DESCRIPTION
Mysql default authentication method has changed in mysql 8 which cause " Authentication plugin 'caching_sha2_password' cannot be loaded". Lock mysql package down.